### PR TITLE
Add navigation bar color option

### DIFF
--- a/app/src/main/java/com/kroegerama/imgpicker/demo/AcMain.kt
+++ b/app/src/main/java/com/kroegerama/imgpicker/demo/AcMain.kt
@@ -1,5 +1,6 @@
 package com.kroegerama.imgpicker.demo
 
+import android.graphics.Color
 import android.net.Uri
 import android.view.LayoutInflater
 import android.widget.ImageView
@@ -26,6 +27,7 @@ class AcMain : BaseActivity(), BottomSheetImagePicker.OnImagesSelectedListener {
             .galleryButton(ButtonType.Button)
             .singleSelectTitle(R.string.pick_single)
             .peekHeight(R.dimen.peekHeight)
+            .navigationBarColor(Color.WHITE)
             .requestTag("single")
             .show(supportFragmentManager)
     }
@@ -34,6 +36,7 @@ class AcMain : BaseActivity(), BottomSheetImagePicker.OnImagesSelectedListener {
         BottomSheetImagePicker.Builder(getString(R.string.file_provider))
             .columnSize(R.dimen.columnSize)
             .multiSelect(3, 6)
+            .navigationBarColor(Color.WHITE)
             .multiSelectTitles(
                 R.plurals.pick_multi,
                 R.plurals.pick_multi_more,

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -1,11 +1,18 @@
-<resources>
+<resources xmlns:tools="http://schemas.android.com/tools">
 
     <!-- Base application theme. -->
-    <style name="AppTheme" parent="Theme.AppCompat.Light.DarkActionBar">
+    <style name="AppTheme" parent="Theme.MaterialComponents.Light.DarkActionBar">
         <!-- Customize your theme here. -->
         <item name="colorPrimary">@color/colorPrimary</item>
         <item name="colorPrimaryDark">@color/colorPrimaryDark</item>
         <item name="colorAccent">@color/colorAccent</item>
+        <item name="bottomSheetDialogTheme">@style/AppTheme.BottomSheetDialogTheme</item>
+    </style>
+
+    <style name="AppTheme.BottomSheetDialogTheme" parent="ThemeOverlay.MaterialComponents.Light.BottomSheetDialog">
+        <item name="android:navigationBarColor" tools:targetApi="lollipop">@android:color/transparent</item>
+        <item name="android:windowIsFloating">false</item>
+        <item name="android:statusBarColor" tools:targetApi="lollipop">@android:color/transparent</item>
     </style>
 
 </resources>

--- a/library/src/main/java/com/kroegerama/imgpicker/BottomSheetImagePicker.kt
+++ b/library/src/main/java/com/kroegerama/imgpicker/BottomSheetImagePicker.kt
@@ -1,7 +1,6 @@
 package com.kroegerama.imgpicker
 
 import android.annotation.SuppressLint
-import android.annotation.TargetApi
 import android.app.Activity.RESULT_OK
 import android.app.Dialog
 import android.content.Context
@@ -17,6 +16,7 @@ import android.provider.MediaStore
 import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
+import android.view.View.SYSTEM_UI_FLAG_LIGHT_NAVIGATION_BAR
 import android.view.ViewGroup
 import android.widget.Toast
 import androidx.annotation.ColorInt
@@ -24,7 +24,6 @@ import androidx.annotation.DimenRes
 import androidx.annotation.PluralsRes
 import androidx.annotation.StringRes
 import androidx.core.content.FileProvider
-import androidx.core.graphics.ColorUtils
 import androidx.core.view.isVisible
 import androidx.fragment.app.FragmentManager
 import androidx.loader.app.LoaderManager
@@ -175,18 +174,25 @@ class BottomSheetImagePicker internal constructor() :
         }
     }
 
-    @TargetApi(Build.VERSION_CODES.O)
     private fun setNavigationBarColor() {
-        dialog?.window?.run {
-            this.navigationBarColor = navigationBarColor
-            if (this.navigationBarColor.isLight) {
-                decorView.systemUiVisibility = decorView.systemUiVisibility or View.SYSTEM_UI_FLAG_LIGHT_NAVIGATION_BAR
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            dialog?.window?.let { window ->
+                window.navigationBarColor = navigationBarColor
+                var systemUIVisibility = window.decorView.systemUiVisibility
+                if (window.navigationBarColor.isLight) {
+                    systemUIVisibility = systemUIVisibility or SYSTEM_UI_FLAG_LIGHT_NAVIGATION_BAR
+                    window.decorView.systemUiVisibility = systemUIVisibility
+                }
             }
         }
     }
 
     private val Int.isLight: Boolean
-        get() = ColorUtils.calculateLuminance(this) < 0.4
+        get() {
+            val darkness: Double =
+                1 - (0.299 * Color.red(this) + 0.587 * Color.green(this) + 0.114 * Color.blue(this)) / 255
+            return darkness < 0.4
+        }
 
     private fun tileClick(tile: ClickedTile) {
         when (tile) {
@@ -474,7 +480,6 @@ class BottomSheetImagePicker internal constructor() :
             this@Builder
         }
 
-        @TargetApi(Build.VERSION_CODES.O)
         fun navigationBarColor(@ColorInt color: Int) = args.run {
             putInt(NAVIGATION_BAR_COLOR, color)
             this@Builder

--- a/library/src/main/res/layout/imagepicker.xml
+++ b/library/src/main/res/layout/imagepicker.xml
@@ -11,7 +11,6 @@
         android:layout_width="match_parent"
         android:layout_height="?android:attr/listPreferredItemHeightSmall"
         android:layout_gravity="bottom"
-        android:background="#fff"
         app:elevation="3dp">
 
         <TextView
@@ -24,7 +23,8 @@
             android:paddingStart="16dp"
             android:paddingEnd="0dp"
             android:text="@string/imagePickerSingle"
-            android:textAppearance="@style/TextAppearance.AppCompat.Subhead" />
+            android:textAppearance="@style/TextAppearance.MaterialComponents.Subtitle2"
+            android:textColor="?android:textColorSecondary" />
 
         <ImageButton
             android:id="@+id/btnClearSelection"


### PR DESCRIPTION
Enables theming of the navigation bar color.
In order to be able to theme the navigation bar color one must extend from the material bottom sheet style like so 
```
    <style name="AppTheme.BottomSheetDialogTheme" parent="ThemeOverlay.MaterialComponents.Light.BottomSheetDialog">
        <item name="android:navigationBarColor" tools:targetApi="lollipop">@android:color/transparent</item>
        <item name="android:windowIsFloating">false</item>
        <item name="android:statusBarColor" tools:targetApi="lollipop">@android:color/transparent</item>
    </style>
```